### PR TITLE
Refactor/allow client reuse format message when the client wants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # swift-log
 
-This repo supports logging in iOS
+This repo supports logging
 
 1. Console Logging
 2. File Logging and sync each configurable timeInterval
@@ -14,10 +14,60 @@ This repo supports logging in iOS
 5. ❗️ Error: An error occurred, but it's recoverable, just info about what happened
 6. 🛑 Severe: A server error occurred
 
-## Prerequisite
+## Prerequisite (Developer only)
 
 - *[SwiftLint](https://github.com/realm/SwiftLint)* enforce Swift style and conventions. Install via Homebrew: ```$ brew install swiftlint```
 - *Standardize* development mode ```$ ./Scripts/setup.sh```
+
+## Requirements
+- Xcode 11.4.1+
+- Swift 5.0
+
+## How
+### Setup
+1. Use Framework's default setup
+```
+import UIKit
+import Logging
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        /// Setup Logging
+        LoggerManager.sharedInstance.initialize()
+        return true
+    }
+}
+```
+2. Customize Logging
+```
+import UIKit
+import Logging
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        /// Setup Logging
+        let logFormatter = LogFormatterImpl()
+        LoggerManager.sharedInstance.addLogging(LoggerFactoryImpl.makeConsoleLogging(logFormatter: logFormatter))
+        LoggerManager.sharedInstance.addLogging(LoggerFactoryImpl.makeFileLogging(fileName: "logs"))
+        /// Disable LogLevels. Enable all LogLevels by default
+        LoggerManager.sharedInstance.disableLogLevels([LogLevel.info, LogLevel.error])
+
+        return true
+    }
+}
+```
+### Use
+```
+Log.info(message: "info")
+Log.debug(message: "debug")
+Log.verbose(message: "verbose")
+Log.warning(message: "warning")
+Log.error(message: "error")
+Log.severe(message: "severe")
+```
 
 ## Installation
 


### PR DESCRIPTION
- [x] Allow client reuse formatter from Framework.
- [x] Validate LogLevels before executing forward to observers
- [x] Update README to guide the client integrate to the app